### PR TITLE
event_scheduler: Remove sched inheritance, add TestTimer

### DIFF
--- a/event_scheduler/test_util.py
+++ b/event_scheduler/test_util.py
@@ -1,0 +1,81 @@
+import threading
+from event_scheduler import EventScheduler
+
+
+class TestTimer(threading.Timer):
+    """The TestTimer is designed to test your code that incorporates the event
+    scheduler. Passing the TestTimer.monotonic and TestTimer into the event
+    scheduler gives you full control of the event scheduler's monotonic time.
+    Passing the event scheduler's condition variable enables full
+    synchronization with the event scheduler's internal thread.
+    """
+    _time = 0
+    _observers = []
+    _event_scheduler = None
+    _cv = None
+
+    @classmethod
+    def monotonic(cls) -> float:
+        if not cls._cv:
+            return cls._time
+        with cls._cv:
+            return cls._time
+
+    @classmethod
+    def advance_time(cls, increment: float) -> None:
+        if increment < 0:
+            raise ValueError('Time increment must be positive.')
+        if not cls._cv:
+            cls._time += increment
+            for observer in cls._observers:
+                observer.run()
+            return
+        with cls._cv:
+            cls._time += increment
+            # synchronize with the event scheduler thread (only advance time
+            # when the thread isn't active.
+            cls._cv.wait_for(lambda: len(cls._cv._waiters) != 0, 1)
+            did_run = False
+            for observer in cls._observers:
+                result = observer.run()
+                did_run = did_run or result
+            # if we executed the function for the timer (in this case a notify
+            # on the condition variable, we have to wait until the event
+            # scheduler has done work (we get notified in that case).
+            if did_run:
+                cls._cv.wait()
+
+    # pass in the event scheduler's condition variable for synchronization.
+    @classmethod
+    def set_event_scheduler(cls, event_scheduler: EventScheduler):
+        cls._event_scheduler = event_scheduler
+        cls._cv = event_scheduler._cv
+
+    @classmethod
+    def reset(cls):
+        cls._time = 0
+        cls._observers = []
+        cls._event_scheduler = None
+        cls._cv = None
+
+    def __init__(self, interval, function, args=None, kwargs=None):
+        threading.Thread.__init__(self)
+        self.done_time = TestTimer.monotonic() + interval
+        self.function = function
+        self.args = args if args is not None else []
+        self.kwargs = kwargs if kwargs is not None else {}
+
+    def start(self):
+        TestTimer._observers.append(self)
+
+    def cancel(self):
+        """Stop the timer if it hasn't finished yet."""
+        if self in TestTimer._observers:
+            TestTimer._observers.remove(self)
+
+    def run(self):
+        if self.done_time <= TestTimer.monotonic():
+            self.function(*self.args, **self.kwargs)
+            TestTimer._observers.remove(self)
+            return True
+        return False

--- a/event_scheduler_tests/unit_tests/event_scheduler_tests.py
+++ b/event_scheduler_tests/unit_tests/event_scheduler_tests.py
@@ -1,9 +1,10 @@
 from event_scheduler.event_scheduler import EventScheduler
+from event_scheduler.test_util import TestTimer
 import unittest
 import time
 
 
-def insert_into_list(item, list_object):
+def insert_into_list(item, list_object: list):
     list_object.append(item)
 
 
@@ -12,28 +13,34 @@ TEST_THREAD = "test_thread"
 
 class EventSchedulerTests(unittest.TestCase):
 
+    def tearDown(self) -> None:
+        TestTimer.reset()
+
     def test_breathing(self):
         event_scheduler = EventScheduler(TEST_THREAD)
         result = event_scheduler.start()
         self.assertEqual(result, 0)
-        time.sleep(1)
         result = event_scheduler.stop()
         self.assertEqual(result, 0)
 
     def test_event_scheduler_stopped(self):
-        event_scheduler = EventScheduler(TEST_THREAD)
+        event_scheduler = EventScheduler(TEST_THREAD,
+                                         TestTimer.monotonic,
+                                         TestTimer)
         result_list = []
         event_scheduler.enter(0, 0, insert_into_list, ('A', result_list))
-        time.sleep(1)
+        TestTimer.advance_time(0)
         self.assertFalse(result_list)
         event_scheduler.start()
         event_scheduler.stop()
         event_scheduler.enter(0, 0, insert_into_list, ('A', result_list))
-        time.sleep(1)
+        TestTimer.advance_time(0)
         self.assertFalse(result_list)
 
     def test_no_double_start_or_stop(self):
-        event_scheduler = EventScheduler(TEST_THREAD)
+        event_scheduler = EventScheduler(TEST_THREAD,
+                                         TestTimer.monotonic,
+                                         TestTimer)
         event_scheduler.start()
         result = event_scheduler.start()
         self.assertEqual(result, -1)
@@ -42,7 +49,9 @@ class EventSchedulerTests(unittest.TestCase):
         self.assertEqual(result, -1)
 
     def test_execute_one_event(self):
-        event_scheduler = EventScheduler(TEST_THREAD)
+        event_scheduler = EventScheduler(TEST_THREAD,
+                                         TestTimer.monotonic,
+                                         TestTimer)
         event_scheduler.start()
         result_list = []
         event_scheduler.enter(0, 0, insert_into_list, ('A', result_list))
@@ -51,32 +60,88 @@ class EventSchedulerTests(unittest.TestCase):
         self.assertEqual(result_list[0], 'A')
 
     def test_relative_delay(self):
-        event_scheduler = EventScheduler(TEST_THREAD)
+        event_scheduler = EventScheduler(TEST_THREAD,
+                                         TestTimer.monotonic,
+                                         TestTimer)
+        TestTimer.set_event_scheduler(event_scheduler)
         event_scheduler.start()
         result_list = []
-        event_scheduler.enter(3, 0, insert_into_list, ('A', result_list))
-        time.sleep(2)
-        self.assertFalse(result_list)
-        time.sleep(2)
-        self.assertTrue(result_list)
-        self.assertEqual(result_list[0], 'A')
+        item = 'A'
+        event_scheduler.enter(3, 0, insert_into_list, (item, result_list))
+        TestTimer.advance_time(2)
+        self.assertListEqual(result_list, [])
+        TestTimer.advance_time(1)
+        self.assertListEqual(result_list, [item])
         event_scheduler.stop()
 
-    # TODO: Make test less flakey (failure depends on speed of execution)
-    @unittest.skip("Flakey test that depends on speed of execution.")
     def test_priority(self):
-        event_scheduler = EventScheduler(TEST_THREAD)
+        event_scheduler = EventScheduler(TEST_THREAD,
+                                         TestTimer.monotonic,
+                                         TestTimer)
+        TestTimer.set_event_scheduler(event_scheduler)
         event_scheduler.start()
         result_list = []
         event_scheduler.enterabs(4, 4, insert_into_list, ('C', result_list))
         event_scheduler.enterabs(4, 3, insert_into_list, ('B', result_list))
         event_scheduler.enterabs(4, 5, insert_into_list, ('D', result_list))
         event_scheduler.enterabs(4, 1, insert_into_list, ('A', result_list))
+        TestTimer.advance_time(3.8)
+        self.assertListEqual(result_list, [])
+        TestTimer.advance_time(0.3)
         event_scheduler.stop()
         self.assertListEqual(result_list, ['A', 'B', 'C', 'D'])
 
-    def test_cancel_event(self):
+    def test_multiple_events_different_times(self):
+        event_scheduler = EventScheduler(TEST_THREAD,
+                                         TestTimer.monotonic,
+                                         TestTimer)
+        TestTimer.set_event_scheduler(event_scheduler)
+        event_scheduler.start()
+        result_list = []
+        event_scheduler.enterabs(5, 1, insert_into_list, ('D', result_list))
+        event_scheduler.enterabs(4, 1, insert_into_list, ('B', result_list))
+        event_scheduler.enterabs(7, 1, insert_into_list, ('E', result_list))
+        event_scheduler.enterabs(1, 1, insert_into_list, ('A', result_list))
+        self.assertListEqual(result_list, [])
+        TestTimer.advance_time(1)
+        self.assertListEqual(result_list, ['A'])
+        TestTimer.advance_time(3)
+        self.assertListEqual(result_list, ['A', 'B'])
+        event_scheduler.enterabs(0.5, 1, insert_into_list, ('C', result_list))
+        TestTimer.advance_time(1)
+        self.assertListEqual(result_list, ['A', 'B', 'C', 'D'])
+        TestTimer.advance_time(2)
+        self.assertListEqual(result_list, ['A', 'B', 'C', 'D', 'E'])
+        event_scheduler.stop()
+
+    def test_multiple_events_built_in_timer(self):
         event_scheduler = EventScheduler(TEST_THREAD)
+        event_scheduler.start()
+        result_list = []
+        event_scheduler.enterabs(0.2, 1, insert_into_list, ('A', result_list))
+        event_scheduler.enterabs(0.4, 1, insert_into_list, ('B', result_list))
+        event_scheduler.enterabs(0.7, 1, insert_into_list, ('C', result_list))
+        event_scheduler.enterabs(1, 1, insert_into_list, ('D', result_list))
+        event_scheduler.stop()
+        self.assertListEqual(result_list, ['A', 'B', 'C', 'D'])
+
+    def test_event_time_in_the_past(self):
+        event_scheduler = EventScheduler(TEST_THREAD,
+                                         TestTimer.monotonic,
+                                         TestTimer)
+        TestTimer.set_event_scheduler(event_scheduler)
+        event_scheduler.start()
+        result_list = []
+        event_scheduler.enterabs(-1, 1, insert_into_list, ('A', result_list))
+        TestTimer.advance_time(0)
+        event_scheduler.stop()
+        self.assertListEqual(result_list, ['A'])
+
+    def test_cancel_event(self):
+        event_scheduler = EventScheduler(TEST_THREAD,
+                                         TestTimer.monotonic,
+                                         TestTimer)
+        TestTimer.set_event_scheduler(event_scheduler)
         event_scheduler.start()
         result_list = []
         event = event_scheduler.enterabs(2,
@@ -84,7 +149,8 @@ class EventSchedulerTests(unittest.TestCase):
                                          insert_into_list,
                                          ('A', result_list))
         event_scheduler.enterabs(2, 3, insert_into_list, ('B', result_list))
-
+        TestTimer.advance_time(1)
         event_scheduler.cancel(event)
+        TestTimer.advance_time(1)
         event_scheduler.stop()
         self.assertListEqual(result_list, ['B'])

--- a/event_scheduler_tests/unit_tests/test_util_tests.py
+++ b/event_scheduler_tests/unit_tests/test_util_tests.py
@@ -1,0 +1,58 @@
+from event_scheduler.test_util import TestTimer
+import unittest
+
+
+def insert_into_list(item, list_object):
+    list_object.append(item)
+
+
+class TestTimerTests(unittest.TestCase):
+
+    def tearDown(self):
+        TestTimer.reset()
+
+    def test_advance_time(self):
+        self.assertEqual(TestTimer.monotonic(), 0)
+        time_passed = 500
+        TestTimer.advance_time(time_passed)
+        self.assertEqual(TestTimer.monotonic(), time_passed)
+        new_time_passed = time_passed + time_passed
+        TestTimer.advance_time(time_passed)
+        self.assertEqual(TestTimer.monotonic(), new_time_passed)
+
+    def test_reset(self):
+        self.assertEqual(TestTimer.monotonic(), 0)
+        time_passed = 500
+        TestTimer.advance_time(time_passed)
+        self.assertEqual(TestTimer.monotonic(), time_passed)
+        TestTimer.reset()
+        self.assertEqual(TestTimer.monotonic(), 0)
+
+    def test_timer_basic_operation(self):
+        result_list = []
+        item = 'A'
+        time_passed = 500
+        test_timer = TestTimer(time_passed,
+                               insert_into_list,
+                               (item, result_list))
+        test_timer.start()
+        self.assertListEqual(result_list, [])
+        TestTimer.advance_time(time_passed-1)
+        self.assertListEqual(result_list, [])
+        TestTimer.advance_time(1)
+        self.assertEqual(result_list, [item])
+
+    def test_timer_cancel(self):
+        result_list = []
+        item = 'A'
+        time_passed = 500
+        test_timer = TestTimer(time_passed,
+                               insert_into_list,
+                               (item, result_list))
+        test_timer.start()
+        self.assertListEqual(result_list, [])
+        TestTimer.advance_time(time_passed - 1)
+        self.assertListEqual(result_list, [])
+        test_timer.cancel()
+        TestTimer.advance_time(1)
+        self.assertEqual(result_list, [])


### PR DESCRIPTION
Removed the sched inheritance so that we don't acquire locks three times in a function. Also added a TestTimer so developers can test their code while controlling the event scheduler event dispatching.